### PR TITLE
feat: pyo3 and rayon dependencies are optional, but active by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,17 @@ homepage = "https://github.com/bast/polygons"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[features]
+
+default = ["rayon", "pyo3"]
+
 [package.metadata.maturin]
 requires-python = ">=3.6"
 classifier = ["Programming Language :: Python"]
 
 [dependencies]
-rand = "0.8.3"
-rayon = "1.5.0"
-pyo3 = { version = "0.13", features = ["extension-module"] }
+rayon = { version = "1.5.0", optional = true }
+pyo3 = { version = "0.13", features = ["extension-module"], optional = true }
+
+[dev-dependencies]
+rand = "0.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,16 @@
 //! Computes distances to polygon edges and vertices and can check whether points are
 //! inside/outside polygons.
 
-mod distance;
-mod intersections;
-mod python;
-mod tree;
-
-pub use crate::tree::Tree;
-
 pub use crate::tree::build_search_tree;
 pub use crate::tree::build_search_tree_h;
-
 pub use crate::tree::distances_nearest_edges;
 pub use crate::tree::distances_nearest_vertices;
 pub use crate::tree::points_are_inside;
+pub use crate::tree::Tree;
+
+mod distance;
+mod intersections;
+#[cfg(feature = "pyo3")]
+mod python;
+mod tree;
+


### PR DESCRIPTION
Fixes #11: Make python/rayon dependencies optional